### PR TITLE
various details, to please the ruff linter

### DIFF
--- a/elliptic_genus/elliptic_genus.py
+++ b/elliptic_genus/elliptic_genus.py
@@ -34,6 +34,7 @@ REFERENCES:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from functools import cache
 
 from sage.all import (
     PolynomialRing,
@@ -42,11 +43,11 @@ from sage.all import (
     QQ,
     Partitions,
     prod,
+    SymmetricFunctions,
 )
-from elliptic_genus.utils import *
+from elliptic_genus.utils import exp_cut, cutoff, todd_cut, chernnum_from_partition
 from homogeneous_space.interfaces import AlmostComplexManifold
-
-from functools import cache
+from homogeneous_space.chern_number import chern_number
 
 
 # qのk次までに必要な係数の計算
@@ -94,7 +95,7 @@ def ell_factor_coeff_degreewise(dim: int, k: int) -> list:
     q_ = R.gen()
 
     S0 = PolynomialRing(QQ, "c", dim + 1)
-    c = S0.gens()  # Chern根の変数
+    # c = S0.gens()  # Chern根の変数
 
     S1 = LaurentPolynomialRing(S0, "y")
     y = S1.gen()
@@ -176,19 +177,19 @@ def ell_factor_coeff(dim: int, k: int) -> list:
          (-1/24*y^-1 + 1/24 + 1/24*y - 1/24*y^2)*q + (-3/4*y^-1 + 3/4 + 3/4*y - 3/4*y^2)*q^2]
 
     """
-    R0 = PolynomialRing(QQ, "x", dim)
-    x = R0.gens()  # Chern根の変数
+    # R0 = PolynomialRing(QQ, "x", dim)
+    # x = R0.gens()  # Chern根の変数
 
-    R1 = LaurentPolynomialRing(R0, "y_")
-    y_ = R1.gen()
-    R = LazyLaurentSeriesRing(R1, "q_")
-    q_ = R.gen()
+    # R1 = LaurentPolynomialRing(R0, "y_")
+    # y_ = R1.gen()
+    # R = LazyLaurentSeriesRing(R1, "q_")
+    # q_ = R.gen()
 
     S0 = PolynomialRing(QQ, "c", dim + 1)
-    c = S0.gens()  # Chern根の変数
+    # c = S0.gens()  # Chern根の変数
 
     S1 = LaurentPolynomialRing(S0, "y")
-    y = S1.gen()
+    # y = S1.gen()
     S = LazyLaurentSeriesRing(S1, "q")
     q = S.gen()
 
@@ -293,10 +294,6 @@ def elliptic_genus_chernnum(dim: int, k: int):
         return sum(
             coeff[part] * chernnum_from_partition(dim, part) for part in Partitions(dim)
         )
-
-
-from homogeneous_space.interfaces import AlmostComplexManifold
-from homogeneous_space.chern_number import chern_number
 
 
 @cache

--- a/elliptic_genus/utils.py
+++ b/elliptic_genus/utils.py
@@ -13,10 +13,8 @@ Module contains common functions used in intermediate calculations
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-import math
 from sage.all import (
     PolynomialRing,
-    LaurentPolynomialRing,
     LazyLaurentSeriesRing,
     QQ,
     SymmetricFunctions,
@@ -33,7 +31,7 @@ def todd_cut(x, m):  # mでカットオフ
 
     INPUT:
 
-    - ``x`` -- the variable of the todd genus for a line bundle.
+    - ``x`` -- the variable of the Todd genus for a line bundle.
 
     - ``m`` -- integer.
 

--- a/homogeneous_space/chern_number.py
+++ b/homogeneous_space/chern_number.py
@@ -43,10 +43,12 @@ REFERENCES:
 from sage.all import prod
 from homogeneous_space.interfaces import AlmostComplexManifold
 
+
 # `degree`次部分を取り出す関数
-homogeneous_part = lambda F, degree: sum(
-    c * m for c, m in F if m.total_degree() == degree
-)
+def homogeneous_part(F, degree):
+    return sum(
+        c * m for c, m in F if m.total_degree() == degree
+    )
 
 
 def chern_number(

--- a/homogeneous_space/complete_intersection.py
+++ b/homogeneous_space/complete_intersection.py
@@ -41,18 +41,20 @@ REFERENCES:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from functools import cache
 
 from sage.all import prod, vector
+
 from homogeneous_space.homogeneous_space import (
     CompletelyReducibleEquivariantVectorBundle,
 )
 from homogeneous_space.interfaces import AlmostComplexManifold, VectorBundle
-from functools import cache
 
 
-homogeneous_part = lambda F, degree: sum(
-    c * m for c, m in F if m.total_degree() == degree
-)
+def homogeneous_part(F, degree):
+    return sum(
+        c * m for c, m in F if m.total_degree() == degree
+    )
 
 
 class CompleteIntersection(AlmostComplexManifold):
@@ -161,18 +163,17 @@ class CompleteIntersection(AlmostComplexManifold):
             )
 
         def geometric_sequence(n, x):
-            return sum(x**i for i in range(0, n + 1))
+            return sum(x**i for i in range(n + 1))
 
         cc = prod(1 + x for x in self.homogeneous_space.tangent_weights) * prod(
             geometric_sequence(self.dim, -class_from_weight(vector(w))) ** i
             for w, i in self.vector_bundle.weight_multiplicities.items()
         )
 
-        return [homogeneous_part(cc, i) for i in range(0, self.dim + 1)]
+        return [homogeneous_part(cc, i) for i in range(self.dim + 1)]
 
     def numerical_integration_by_localization(self, f):
         r"""
-
         Return the numerical computation of the integration of equivariant cohomology classes.
 
         INPUT:

--- a/homogeneous_space/euler_characteristic.py
+++ b/homogeneous_space/euler_characteristic.py
@@ -75,11 +75,11 @@ def euler_characteristic(
 
     """
     chern_character = vector_bundle.chern_character()
-    todd_classes = variety.todd_classes()
+    todd_classes = manifold.todd_classes()
 
-    return variety.integration(
+    return manifold.integration(
         sum(
-            chern_character[i] * todd_classes[variety.dimension() - i]
-            for i in range(0, variety.dimension() + 1)
+            chern_character[i] * todd_classes[manifold.dimension() - i]
+            for i in range(manifold.dimension() + 1)
         )
     )

--- a/homogeneous_space/homogeneous_space.py
+++ b/homogeneous_space/homogeneous_space.py
@@ -44,18 +44,20 @@ AUTHORS:
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-
+from functools import cache
 from random import random
-from sage.all import PolynomialRing, QQ, prod, RealField, vector, WeylGroup, Matrix
+
+from sage.all import PolynomialRing, QQ, prod, RealField, vector, WeylGroup
+
 from homogeneous_space.parabolic import ParabolicSubgroup
 from homogeneous_space.interfaces import AlmostComplexManifold, VectorBundle
-from functools import cache
 
 
 # `degree`次部分を取り出す関数
-homogeneous_part = lambda F, degree: sum(
-    c * m for c, m in F if m.total_degree() == degree
-)
+def homogeneous_part(F, degree):
+    return sum(
+        c * m for c, m in F if m.total_degree() == degree
+    )
 
 
 class HomogeneousSpace(AlmostComplexManifold):
@@ -156,7 +158,7 @@ class HomogeneousSpace(AlmostComplexManifold):
         """
         return [
             homogeneous_part(prod(1 + x for x in self.tangent_weights), i)
-            for i in (range(0, self.dim + 1))
+            for i in range(self.dim + 1)
         ]
 
     @cache

--- a/homogeneous_space/interfaces.py
+++ b/homogeneous_space/interfaces.py
@@ -164,7 +164,7 @@ class VectorBundle(ABC):
             order=TermOrder("wdeglex", tuple(range(1, len_cc + 1))),
         )
 
-        # Using Singular, calculate universal formula of chern character
+        # Using Singular, calculate universal formula of Chern character
         singular.lib("chern.lib")
         r = singular.ring(0, f"(c(1..{len_cc}))", "dp")
         l = singular.list(f"c(1..{len_cc})")
@@ -179,14 +179,14 @@ class VectorBundle(ABC):
 
         return [
             chern_character[i](chern_classes)
-            for i in (range(0, self.base().dimension() + 1))
+            for i in range(self.base().dimension() + 1)
         ]
 
     def chern_character_total(self):
         r"""
         Return the Chern characters of this vector bundle
         """
-        return sum(c for c in self.chern_character())
+        return sum(self.chern_character())
 
     def todd_classes(self) -> list:
         r"""
@@ -212,7 +212,7 @@ class VectorBundle(ABC):
 
         return [
             todd_classes[i](chern_classes)
-            for i in (range(0, self.base().dimension() + 1))
+            for i in range(self.base().dimension() + 1)
         ]
 
     def dual(self) -> VectorBundle:
@@ -250,18 +250,19 @@ def direct_sum(vector_bundle1: VectorBundle, vector_bundle2: VectorBundle):
     rank = vector_bundle1.rank() + vector_bundle2.rank()
     base = vector_bundle1.base()
 
-    cc = sum(c1 for c1 in vector_bundle1.chern_classes()) * sum(
-        c2 for c2 in vector_bundle2.chern_classes()
+    cc = sum(vector_bundle1.chern_classes()) * sum(
+        vector_bundle2.chern_classes()
     )
 
     # `degree`次部分を取り出す関数
-    homogeneous_part = lambda F, degree: sum(
-        c * m for c, m in F if m.total_degree() == degree
-    )
+    def homogeneous_part(F, degree):
+        return sum(
+            c * m for c, m in F if m.total_degree() == degree
+        )
 
     chern_classes = [
         homogeneous_part(cc, i)
-        for i in (range(0, vector_bundle1.base().dimension() + 1))
+        for i in (range(vector_bundle1.base().dimension() + 1))
     ]
 
     class VB(VectorBundle):

--- a/homogeneous_space/parabolic.py
+++ b/homogeneous_space/parabolic.py
@@ -49,7 +49,7 @@ REFERENCES:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.all import matrix, vector, WeylCharacterRing, CartanType
+from sage.all import matrix, vector, WeylCharacterRing
 
 
 # 最高ウェイト表現のウェイトを最高ウェイトとの差で表す関数。

--- a/weak_Jacobi_form/basis.py
+++ b/weak_Jacobi_form/basis.py
@@ -37,8 +37,8 @@ REFERENCES:
 # ****************************************************************************
 
 import math
+
 from sage.all import LaurentPolynomialRing, LazyLaurentSeriesRing, QQ, bernoulli, sigma
-from weak_Jacobi_form.eisenstein import lazy_eisenstein_series_qexp
 
 _R0 = LaurentPolynomialRing(QQ, "y")
 _y = _R0.gen()
@@ -349,7 +349,7 @@ def basis_integral(weight: int, index: int) -> list:
 
     result = []
     # result.append(_phi_tilde_0_1() ** index)
-    for i in range(0, index + 1):
+    for i in range(index + 1):
         phi = _phi_tilde_0_1() ** (index - i) * _phi_tilde_m2_1() ** i
         for i, j in _decompose(i + int(weight / 2)):
             e = eisenstein(4) ** i * eisenstein(6) ** j


### PR DESCRIPTION
namely make so that the command
````
ruff --ignore=E501,E741 .
````
only returns a few warnings.